### PR TITLE
initialize nvim telescope plugin

### DIFF
--- a/vims/Makefile
+++ b/vims/Makefile
@@ -1,5 +1,9 @@
+VUNDLE_URL=https://github.com/VundleVim/Vundle.vim.git
+VUNDLE=~/.vim/bundle/Vundle.vim
 VIMRC=~/.vimrc
-NVIMRC=~/.config/nvim/init.vim
+NVIM_HOME=~/.config/nvim
+NVIMRC=$(NVIM_HOME)/init.vim
+NVIMRC_LUA=$(NVIM_HOME)/lua
 
 .PHONY: all
 all: backup vundle vimrc nvimrc install
@@ -12,8 +16,7 @@ nvim: backup vundle nvimrc install
 
 .PHONY: vundle
 vundle:
-	test -d ~/.vim/bundle/Vundle.vim || \
-	git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
+	if [ ! -d $(VUNDLE) ]; then git clone $(VUNDLE_URL) $(VUNDLE); fi
 
 .PHONY: install
 install:
@@ -22,18 +25,22 @@ install:
 # creates ~/.backup to avoid .vim*~ files littering the cwd
 .PHONY: backup
 backup:
-	test -d ~/.backup || mkdir ~/.backup
+	if [ ! -d ~/.backup ]; then mkdir ~/.backup; fi
 
 .PHONY: vimrc
 vimrc:
-	test -f ~/.vimrc && rm -f ~/.vimrc
+	if [ -f ~/.vimrc ]; then rm -f ~/.vimrc; fi
 	sed "s#source #source `pwd`/common/#" common/init.vim  > $(VIMRC)
 	echo >> $(VIMRC)
 	sed "s#source #source `pwd`/vim/#" vim/init.vim >> $(VIMRC)
 
 .PHONY: nvimrc
 nvimrc:
+	# create init.vim
 	test -f $(NVIMRC) && rm -f $(NVIMRC)
 	sed "s#source #source `pwd`/common/#" common/init.vim  > $(NVIMRC)
 	echo >> $(NVIMRC)
 	sed "s#source #source `pwd`/nvim/#" nvim/init.vim >> $(NVIMRC)
+	# link lua directory
+	if [ -d $(NVIMRC_LUA) ]; then rm -rf $(NVIMRC_LUA); fi
+	ln -s `pwd`/nvim/lua $(NVIMRC_LUA)

--- a/vims/common/plugin/nerdtree.vim
+++ b/vims/common/plugin/nerdtree.vim
@@ -1,1 +1,1 @@
-map <Leader>f   :NERDTreeToggle<CR>
+map <Leader>ft	:NERDTreeToggle<cr>

--- a/vims/nvim/plugin/telescope.vim
+++ b/vims/nvim/plugin/telescope.vim
@@ -1,0 +1,22 @@
+" file pickers
+nnoremap <leader>pf <cmd>lua require('telescope.builtin').find_files()<cr>
+nnoremap <leader>pg <cmd>lua require('telescope.builtin').live_grep()<cr>
+nnoremap <leader>pa <cmd>lua require('telescope.builtin').file_browser()<cr>
+
+" lsp pickers
+nnoremap <leader>ps <cmd>lua require('telescope.builtin').lsp_workspace_symbols()<cr>
+nnoremap <leader>pr <cmd>lua require('telescope.builtin').lsp_references()<cr>
+nnoremap <leader>pd <cmd>lua require('telescope.builtin').lsp_definitions()<cr>
+
+" git pickers
+nnoremap <leader>gf <cmd>lua require('telescope.builtin').git_files()<cr>
+nnoremap <leader>gb <cmd>lua require('telescope.builtin').git_branches()<cr>
+nnoremap <leader>gt <cmd>lua require('telescope.builtin').git_status()<cr>
+nnoremap <leader>gc <cmd>lua require('telescope.builtin').git_commits()<cr>
+nnoremap <leader>gs <cmd>lua require('telescope.builtin').git_stash()<cr>
+
+" vim pickers
+nnoremap <leader>pb <cmd>lua require('telescope.builtin').buffers()<cr>
+nnoremap <leader>ph <cmd>lua require('telescope.builtin').help_tags()<cr>
+nnoremap <leader>pm <cmd>lua require('telescope.builtin').man_pages()<cr>
+nnoremap <leader>po <cmd>lua require('telescope.builtin').oldfiles()<cr>


### PR DESCRIPTION
Added keymaps for telescope pickers in `vims/nvim/plugin/telescope.vim`, created an empty lua file for telescope in `vims/nvim/lua`.

Also fixed errors in Makefile and added creation of symbolic link to nvim lua dir when initializing nvim.